### PR TITLE
imgタグからImageタグに修正した。

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "openweathermap.org",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import axios from 'axios';
+import Image from 'next/image';
 
 interface WeatherData {
   name: string;
@@ -101,9 +102,12 @@ export default function Home() {
                 </h2>
                 
                 <div className="text-center mb-4">
-                  <img
+                  <Image
                     src={`https://openweathermap.org/img/wn/${weatherData.weather[0].icon}@2x.png`}
                     alt={weatherData.weather[0].description}
+                    width={80}
+                    height={80}
+                    priority
                     className="mx-auto w-20 h-20"
                   />
                   <p className="text-lg text-gray-600 capitalize">


### PR DESCRIPTION
##修正理由
- Next.jsのESLintルールルールで、<img>を使うとLCP(最大視覚コンテンツの表示)悪化等の無駄が起きやすいとの
エラーが発生。

##修正内容
- <img>から<Image>に変更。